### PR TITLE
Add live frame counter and event dispatch notifications to UI

### DIFF
--- a/src/streamlit_app/pages/chat_video_analysis.py
+++ b/src/streamlit_app/pages/chat_video_analysis.py
@@ -32,35 +32,26 @@ S3_PREFIX = Connections.s3_prefix
 _icons = os.path.join(os.path.dirname(__file__), "..", "..", "..", "assets", "icons")
 
 
-@st.fragment
+@st.fragment(run_every=5)
 def video_stream_section():
     config: Config = st.session_state[CONFIG]
     if not config.stream_url:
         st.info("No video stream provided - chat only mode activated")
         return
 
-    # Create a permanent container for the video
-    if "video_container" not in st.session_state:
-        st.session_state.video_container = st.empty()
-
     if "video_initialized" not in st.session_state:
         logger.info("First time initializing video")
 
-        # Display video in the permanent container
-        with st.session_state.video_container:
-            if config.stream_url == "0":
-                config.stream_url = 0
-                st.camera_input("Camera capture")
-            else:
-                # Display video
-                st.video(config.stream_url, autoplay=True)
-
-        # Create status containers
-        st.session_state.status_container = st.empty()
-        st.session_state.events_container = st.container()
+        # Display video
+        if config.stream_url == "0":
+            config.stream_url = 0
+            st.camera_input("Camera capture")
+        else:
+            st.video(config.stream_url, autoplay=True)
 
         # Initialize processing components
         ctx = multiprocessing.get_context("spawn")
+        event_queue = ctx.Queue()
         source = VideoStreamSource(ctx, config.stream_url, queue_size=250)
         chain = FrameProcessorChain(
             [
@@ -82,6 +73,7 @@ def video_stream_section():
                 LambdaProcessor(
                     response_handler=ResponseHandler(Connections.lambda_function_name, Connections.lambda_client_provider),
                     monitoring_instructions=config.monitoring_instructions,
+                    event_queue=event_queue,
                 ),
             ]
         )
@@ -90,6 +82,8 @@ def video_stream_section():
         st.session_state.source = source
         st.session_state.processor = processor
         st.session_state.sink = sink
+        st.session_state.event_queue = event_queue
+        st.session_state.dispatched_events = []
 
         # Define the processing function
         def process_video():
@@ -129,31 +123,47 @@ def video_stream_section():
         import threading
 
         processing_thread = threading.Thread(target=process_video, daemon=True)
-        # button to change source.running to false
         st.button("Stop", on_click=lambda: source.stop())
         processing_thread.start()
 
         st.session_state.video_initialized = True
         st.session_state.processing_complete = False
     else:
-        # Rerender the video in the same container on page refreshes
-        with st.session_state.video_container:
-            if config.stream_url == 0:
-                st.camera_input("Camera capture")
-            else:
-                # Display video
-                st.video(config.stream_url, autoplay=True)
-
-    # Status updates (in main thread)
-    with st.session_state.status_container:
-        if not st.session_state.get("processing_complete", False):
-            st.info(
-                f"Processing video stream... Frame: {st.session_state.get('current_frame', 0)}"
-            )
-            if error := st.session_state.get("processing_error"):
-                st.error(f"Processing error: {error}")
+        # Rerender the video on fragment reruns
+        if config.stream_url == 0:
+            st.camera_input("Camera capture")
         else:
-            st.success("Video processing complete!")
+            st.video(config.stream_url, autoplay=True)
+
+    # Drain event_queue into session state
+    if "event_queue" in st.session_state and "dispatched_events" in st.session_state:
+        eq = st.session_state.event_queue
+        while not eq.empty():
+            try:
+                st.session_state.dispatched_events.append(eq.get_nowait())
+            except Exception:
+                break
+
+    # Status updates - rendered fresh each fragment rerun
+    if not st.session_state.get("processing_complete", False):
+        frame_count = 0
+        if "source" in st.session_state:
+            frame_count = st.session_state.source.frame_count
+        st.info(f"Processing video stream... Frame: {frame_count}")
+        if error := st.session_state.get("processing_error"):
+            st.error(f"Processing error: {error}")
+    else:
+        st.success("Video processing complete!")
+
+    # Show dispatched events
+    events = st.session_state.get("dispatched_events", [])
+    if events:
+        st.markdown("**Agent Events**")
+        for evt in events:
+            st.info(
+                f"Event dispatched at {evt['timestamp']} | "
+                f"Image: `{evt['s3_key']}`"
+            )
 
 
 def header():
@@ -162,8 +172,8 @@ def header():
     """
     # --- Set up the page ---
     st.set_page_config(
-        page_title="Bedrock Video Monitoring Agent & Chatbot",
-        page_icon=":video_camera:",
+        page_title="Video Monitoring Agent",
+        page_icon=":material/videocam:",
         layout="centered",
     )
 
@@ -209,7 +219,7 @@ def show_message():
     """
 
     # --- Start the session when there is user input ---
-    user_input = st.text_input("# **Question:** 👇", "", key="input")
+    user_input = st.text_input("Question", "", key="input")
 
     logger.info(f"user_input: {user_input}")
     # Start a new conversation
@@ -236,9 +246,9 @@ def show_message():
                     response_output["source"], str
                 ):
                     source_title = (
-                        "\n\n **Source**:" + "\n\n" + response_output["source"]
+                        "\n\nSource: " + response_output["source"]
                     )
-                answer = "**Answer**: \n\n" + response_output["answer"]
+                answer = response_output["answer"]
             except Exception as e:
                 answer = f"Error in get_response: {e}. Response: {response_output}"
                 logger.error(answer)

--- a/src/streamlit_app/shared/logic.py
+++ b/src/streamlit_app/shared/logic.py
@@ -52,9 +52,10 @@ class VideoStreamSource:
         self._video_source = video_source
         self._output = ctx.JoinableQueue(maxsize=queue_size)
         self._running = ctx.Value("b", False)
+        self._frame_count = ctx.Value("i", 0)
         self._producer: ctx.Process = ctx.Process(
             target=self._capture_frames,
-            args=(self._video_source, self._output, self._running),
+            args=(self._video_source, self._output, self._running, self._frame_count),
             daemon=True,
         )
 
@@ -89,6 +90,10 @@ class VideoStreamSource:
     def running(self):
         return self._running.value
 
+    @property
+    def frame_count(self):
+        return self._frame_count.value
+
     @staticmethod
     def get_frame(stream: cv2.VideoCapture):
         # https://docs.opencv.org/4.10.0/d4/d15/group__videoio__flags__base.html#gaeb8dd9c89c10a5c63c139bf7c4f5704d
@@ -102,7 +107,7 @@ class VideoStreamSource:
         return success, Frame(frame, timestamp, index, fps)
 
     @staticmethod
-    def _capture_frames(video_source, frame_queue, running):
+    def _capture_frames(video_source, frame_queue, running, frame_count):
         # https://docs.opencv.org/4.10.0/d8/dfe/classcv_1_1VideoCapture.html
         stream = cv2.VideoCapture(video_source)
 
@@ -112,6 +117,7 @@ class VideoStreamSource:
                 if not success:
                     running.value = False
                     break
+                frame_count.value = int(frame.index)
                 frame_queue.put(frame)
             else:
                 sleep(0.1)

--- a/src/streamlit_app/shared/processors.py
+++ b/src/streamlit_app/shared/processors.py
@@ -6,7 +6,7 @@
 
 import uuid
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import cv2
@@ -70,11 +70,12 @@ class S3Storage(FrameProcessor):
 
 
 class LambdaProcessor(FrameProcessor):
-    def __init__(self, response_handler, monitoring_instructions):
+    def __init__(self, response_handler, monitoring_instructions, event_queue=None):
         logger.info("LambdaProcessor init")
         self.response_handler = response_handler
         self.monitoring_instructions = monitoring_instructions
         self.session_id = "motion_" + str(uuid.uuid4())
+        self.event_queue = event_queue
 
     def process(self, frame: Frame) -> Frame:
         try:
@@ -94,6 +95,12 @@ class LambdaProcessor(FrameProcessor):
                     "agent_response": response,
                 }
             )
+
+            if self.event_queue is not None:
+                self.event_queue.put({
+                    "s3_key": frame.metadata["s3_key"],
+                    "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+                })
 
         except Exception as e:
             logger.error(f"Error in Lambda processing: {str(e)}")


### PR DESCRIPTION
## Changes

### Live frame counter
- Added `multiprocessing.Value` to `VideoStreamSource` that tracks the current frame index across the process boundary
- UI reads the shared value on each fragment rerun so the status bar shows actual progress (e.g. `Frame: 371`) instead of being stuck at 0

### Event dispatch notifications
- Added an optional `event_queue` (`multiprocessing.Queue`) to `LambdaProcessor`
- When an event is dispatched to the Bedrock agent, the processor pushes `{s3_key, timestamp}` into the queue
- The UI drains the queue each fragment cycle and displays confirmed dispatches under an **Agent Events** section

### Auto-refreshing status
- Changed `@st.fragment` to `@st.fragment(run_every=5)` so the status area polls every 5 seconds
- Removed stored `st.empty()` / `st.container()` references that broke on fragment reruns — status and events now render inline

### UI cleanup
- Removed emojis and heavy markdown formatting for a professional look
- Cleaned up page title and icon to use material icons

## Files changed
- `src/streamlit_app/shared/logic.py` — frame counter shared value
- `src/streamlit_app/shared/processors.py` — event queue in LambdaProcessor
- `src/streamlit_app/pages/chat_video_analysis.py` — UI wiring and cleanup